### PR TITLE
Fix for tag race condition and disabling pushing of latest

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -81,6 +81,13 @@ read_list_property() {
   [[ ${#result[@]} -gt 0 ]] || return 1
 }
 
+# Shorthand for reading env config
+function plugin_read_config() {
+  local var="$BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_{1}"
+  local default="${2:-}"
+  echo "${!var:-$default}"
+}
+
 push_tags() {
   local tags=("${@}")
 
@@ -116,7 +123,7 @@ read_tags 'TAGS'
 if [[ ${BUILDKITE_BRANCH} == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
   read_build_args 'DEFAULT_ARGS'
   read_tags 'DEFAULT_TAGS'
-  if [ -z "$ECR_PUBLISH_SKIP_LATEST" ]; then
+  if [[ "$(plugin_read_config SKIP_LATEST_PUSH "false")" == "false" ]] ; then
     tags+=('latest')
   fi
 else

--- a/hooks/command
+++ b/hooks/command
@@ -86,7 +86,7 @@ push_tags() {
 
   for tag in "${tags[@]}"; do
     echo "Tag: '${tag}'"
-    docker tag "${image}" "${image}:${tag}"
+    docker tag "${image}:${BUILDKITE_COMMIT}" "${image}:${tag}"
     docker push "${image}:${tag}"
   done
 }
@@ -116,7 +116,9 @@ read_tags 'TAGS'
 if [[ ${BUILDKITE_BRANCH} == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
   read_build_args 'DEFAULT_ARGS'
   read_tags 'DEFAULT_TAGS'
-  tags+=('latest')
+  if [ -z "$ECR_PUBLISH_SKIP_LATEST" ]; then
+    tags+=('latest')
+  fi
 else
   read_build_args 'BRANCH_ARGS'
   read_tags 'BRANCH_TAGS'
@@ -126,7 +128,7 @@ echo '--- Building Docker image'
 echo "Build args:" ${build_args[@]+"${build_args[@]}"}
 echo "Cache from:" ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
-docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} .
+docker build --file "${dockerfile}" --tag "${image}:${BUILDKITE_COMMIT}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} .
 
 echo '--- Pushing Docker image'
 push_tags "${tags[@]}"

--- a/hooks/command
+++ b/hooks/command
@@ -81,13 +81,6 @@ read_list_property() {
   [[ ${#result[@]} -gt 0 ]] || return 1
 }
 
-# Shorthand for reading env config
-function plugin_read_config() {
-  local var="$BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_{1}"
-  local default="${2:-}"
-  echo "${!var:-$default}"
-}
-
 push_tags() {
   local tags=("${@}")
 
@@ -123,7 +116,7 @@ read_tags 'TAGS'
 if [[ ${BUILDKITE_BRANCH} == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
   read_build_args 'DEFAULT_ARGS'
   read_tags 'DEFAULT_TAGS'
-  if [[ "$(plugin_read_config SKIP_LATEST_PUSH "false")" == "false" ]] ; then
+  if [[ "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_SKIP_LATEST_PUSH:-false}" == "false" ]] ; then
     tags+=('latest')
   fi
 else

--- a/plugin.yml
+++ b/plugin.yml
@@ -17,6 +17,8 @@ configuration:
       type: [array, string]
     default-tags:
       type: [array, string]
+    skip-latest-push:
+      type: boolean
     dockerfile:
       type: string
     ecr-name:


### PR DESCRIPTION
If there are multiple agents sharing the same machine and are building an image for the same repo in the same registry, then they would currently encounter a race condition as they'd tag their images with the same name. This commit attempts to solve the issue by introducing the buildkite commit sha to the original name. We also enabled the ability to skip deploying to production by checking to see if an envar for disabling the push of latest is set.