### PR TITLE
Adding new optional arg to specify ecr region

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -5,7 +5,7 @@ set -euo pipefail
 get_ecr_url() {
   local repository_name="${1}"
 
-  aws ecr describe-repositories \
+  aws ecr describe-repositories ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_REGION:+ --region "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_REGION}"} \
     --repository-names "${repository_name}" \
     --output text \
     --query 'repositories[0].repositoryUri'

--- a/hooks/command
+++ b/hooks/command
@@ -5,7 +5,8 @@ set -euo pipefail
 get_ecr_url() {
   local repository_name="${1}"
 
-  aws ecr describe-repositories ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_REGION:+ --region "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_REGION}"} \
+  aws ecr describe-repositories \
+    ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_REGION:+ --region "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_REGION}"} \
     --repository-names "${repository_name}" \
     --output text \
     --query 'repositories[0].repositoryUri'

--- a/plugin.yml
+++ b/plugin.yml
@@ -21,6 +21,8 @@ configuration:
       type: boolean
     dockerfile:
       type: string
+    ecr-region:
+      type: string
     ecr-name:
       type: string
     skip-build-number-push:


### PR DESCRIPTION
One of the first steps of the plugin is to run ecr describe-repositories to find data of what it's to publish. Right now, it has no option but to use the default region, which leads to issues when handling multiple regions of ecr. This commit adds an argument to pass in the region to the command's call too.